### PR TITLE
fix: Align menu management cards action buttons consistently

### DIFF
--- a/src/pages/admin/MenuManagement.jsx
+++ b/src/pages/admin/MenuManagement.jsx
@@ -254,7 +254,7 @@ const MenuManagement = () => {
       {/* Liste des articles */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {filteredItems.map((item) => (
-          <div key={item.id} className="bg-white rounded-lg shadow-sm overflow-hidden">
+          <div key={item.id} className="bg-white rounded-lg shadow-sm overflow-hidden flex flex-col">
             <div className="relative">
               <ImageWithFallback
                 src={item.image}
@@ -272,7 +272,7 @@ const MenuManagement = () => {
               </div>
             </div>
 
-            <div className="p-4">
+            <div className="p-4 flex flex-col flex-1">
               <div className="flex justify-between items-start mb-2">
                 <h3 className="text-lg font-semibold text-gray-900">{item.name}</h3>
                 <span className="text-lg font-bold text-primary-600">€{item.price.toFixed(2)}</span>
@@ -298,7 +298,7 @@ const MenuManagement = () => {
                 </div>
               )}
 
-              <div className="flex space-x-2">
+              <div className="flex space-x-2 mt-auto">
                 <button
                   onClick={() => openEditModal(item)}
                   className="flex-1 flex items-center justify-center space-x-1 px-3 py-2 bg-blue-100 text-blue-700 rounded-md hover:bg-blue-200 transition-colors"


### PR DESCRIPTION
## Summary
This PR fixes the alignment issue of action buttons ("modifier", "rendre disponible/indisponible", "supprimer") in menu management cards by ensuring they appear at the same level across all cards regardless of content variations.

## Problem
- Action buttons were positioned differently across cards due to variable content heights
- Cards with more content (longer descriptions, allergens) pushed buttons lower
- Cards with minimal content had buttons positioned higher up
- This created an inconsistent and unprofessional user interface

## Solution
Applied CSS Flexbox layout changes to ensure consistent button positioning:

### Technical Changes
- **Card Container**: Added `flex flex-col` to establish vertical flex layout
- **Content Area**: Added `flex flex-col flex-1` to allow content expansion while maintaining structure  
- **Button Group**: Added `mt-auto` to automatically push buttons to bottom of each card

### Files Modified
- `src/pages/admin/MenuManagement.jsx`: Updated CSS classes for card layout structure

## Benefits
- ✅ Consistent button alignment across all menu management cards
- ✅ Professional and polished user interface
- ✅ Better user experience for restaurant managers
- ✅ Maintains all existing functionality and responsive design
- ✅ Pure CSS solution with no JavaScript changes required

## Test Plan
- [x] Verify development server starts without errors
- [x] Confirm button alignment works with cards of different content heights
- [x] Test responsiveness across different screen sizes (grid still works: 1 col mobile, 2 col tablet, 3 col desktop)
- [x] Ensure all button functionality remains intact (edit, toggle availability, delete)
- [x] Verify no regressions in card layout or styling

## Before/After
**Before**: Buttons appeared at different vertical positions depending on card content  
**After**: All button groups aligned consistently at the bottom of each card

Closes #6

🤖 Generated with [Claude Code](https://claude.ai/code)